### PR TITLE
Add target API version configuration

### DIFF
--- a/tools/docs/psa-api-tool-notes.md
+++ b/tools/docs/psa-api-tool-notes.md
@@ -547,8 +547,9 @@ definition is provided in the `:definition:` option. For a function-like macro:
 Common options:
 
 - `:definition:` (optional) - provide the macro definition.
-- `:api-version: <type>` (optional) - define the macro using the document version
-  (from conf.py). `type` is one of `major`, `minor`, or `hex` which results in the
+- `:api-version: <type>` (optional) - define the macro using the target API version
+  (the optional `api_version` value in `doc_info`, or `version` when it is omitted).
+  `type` is one of `major`, `minor`, or `hex` which results in the
   macro definition being the major version, minor version, or a 16-bit
   `(major << 8) | minor` value respectively. This option cannot be used at the same
   time as `:definition:`.

--- a/tools/docs/using-psa-api-tool.md
+++ b/tools/docs/using-psa-api-tool.md
@@ -224,7 +224,8 @@ Important `doc_info` keys used by these specifications include:
 | --- | --- |
 | `template` | Template directory under `tools/templates/`. |
 | `title` | Document title used by Sphinx and the title page. |
-| `version` | Base API version, normally `X.Y`. |
+| `version` | Required document lifecycle version. This is the Sphinx version and is used for document release labels, filenames, and `|docversion|`. |
+| `api_version` | Optional target API version, normally `X.Y`. It defaults to `version` for compatibility. It is used for `|APIversion|`, `|majorversion|`, `|minorversion|`, `|hexversion|`, and `:api-version:` macro values. |
 | `issue_no` | Document issue or maintenance revision. |
 | `draft` | Draft flag or draft revision, depending on the selected publication model. |
 | `release_candidate` | Release-candidate number for existing Arm-style documents. |
@@ -234,6 +235,17 @@ Important `doc_info` keys used by these specifications include:
 | `error_order` | Document-wide order for generated return values. |
 | `identifier_index` | Controls the generated C identifier index. |
 | `prolog_files` | Shared substitution files included in the Sphinx prolog. |
+
+`version` identifies the document lifecycle version. The optional `api_version`
+identifies the API described by the document and must use `X.Y` format. If it is
+omitted, the tool derives the API version from the document version's major and
+minor components, so a document version of `1.5.0` describes API version `1.5`.
+
+An explicit `api_version` can match the document's major/minor version. For a
+non-published document it can instead target only the next minor version or the
+next major version. Published documents must describe the API with the same
+major/minor version as the document. Invalid API-version settings stop the build
+with a configuration diagnostic.
 
 For detailed directive and role behavior, use `psa-api-tool-notes.md` as the editing
 reference.

--- a/tools/psa-api-conf.py
+++ b/tools/psa-api-conf.py
@@ -142,6 +142,13 @@ def split_version(version):
         s.append(0)
     return s[0], s[1]
 
+def api_version_parts(version):
+    if not isinstance(version, str) or not re.fullmatch(r'[0-9]+\.[0-9]+', version):
+        raise ValueError(
+            'Invalid doc_info.api_version value {!r}; expected an API version in X.Y format.'
+            .format(version))
+    return tuple(int(x) for x in version.split('.'))
+
 # -- Build PSA API specification configuration -----------------------------------
 
 now = date.today()
@@ -156,7 +163,10 @@ title = title[-1]
 
 project = doc_info.get('project', fulltitle)
 author = doc_info.get('author', 'Unattributed')
+# The document version describes the published document lifecycle. The API
+# version can differ for drafts that describe a future API release.
 version = doc_info['version']
+api_version_configured = 'api_version' in doc_info
 owner = doc_info.get('owner')
 copyright_date = doc_info.get('copyright_date', now.strftime('%Y'))
 doc_id = doc_info.get('doc_id', '<<Document ID>>')
@@ -228,7 +238,33 @@ docdate = nowdate if status == 'DFT' else doc_info.get('date', nowdate)
 c_index = doc_info.get('identifier_index', True)
 page_break = doc_info.get('page_break', template_info.get('page_break','appendix'))
 
-majorversion, minorversion = split_version(version)
+document_majorversion, document_minorversion = split_version(version)
+document_api_version = '{}.{}'.format(document_majorversion, document_minorversion)
+if api_version_configured:
+    majorversion, minorversion = api_version_parts(doc_info['api_version'])
+    api_version = '{}.{}'.format(majorversion, minorversion)
+else:
+    majorversion, minorversion = document_majorversion, document_minorversion
+    api_version = document_api_version
+
+if status in ('MEM', 'PUB'):
+    if api_version != document_api_version:
+        raise ValueError(
+            'Invalid doc_info.api_version value {}: a published document at version {} '
+            'must describe API version {}.'.format(
+                api_version, version, document_api_version))
+elif api_version_configured:
+    next_minor = (document_majorversion, document_minorversion + 1)
+    next_major = (document_majorversion + 1, 0)
+    if (majorversion, minorversion) not in (
+            (document_majorversion, document_minorversion), next_minor, next_major):
+        raise ValueError(
+            'Invalid doc_info.api_version value {} for document version {}: a '
+            'non-published document must describe the current API version {}, '
+            'the next minor version {}.{}, or the next major version {}.0.'.format(
+                api_version, version, document_api_version,
+                *next_minor, next_major[0]))
+
 extension = doc_info.get('extension_doc', None)
 if extension:
     if extension == True:
@@ -277,7 +313,7 @@ doc_terms = {
     'doclatextitle': latextitle,            #  P
     'doctitle': title,                      # FPG
     'API': title,                           #AF
-    'APIversion': version,                  #A  P
+    'APIversion': api_version,              #A  P
     'docversion': version,                  # legacy usage
     'majorversion' : '``{}``'.format(majorversion), # F
     'minorversion' : '``{}``'.format(minorversion), # F
@@ -315,6 +351,8 @@ logo_file = template_info['logo_file']
 primary_domain = 'psa_c'
 
 psa_api_license = doc_info.get('license', 'missing')
+
+psa_api_api_version = api_version
 
 psa_api_c_header = doc_info.get('header', filename)
 

--- a/tools/psa-api-tool.py
+++ b/tools/psa-api-tool.py
@@ -1978,7 +1978,7 @@ class Macro(C_Item):
                 error = self.state_machine.reporter.error(
                 'Cannot provide arguments for version macro "{}"'.format(self.item_name),
                 line=self.lineno)
-            version = self.env.config.version.split()[0]
+            version = self.env.config.psa_api_api_version
             v = [int(x) for x in version.split('.')]
             if len(v) == 1:
                 v.append(0)
@@ -2603,6 +2603,7 @@ def setup(app):
     app.add_config_value('psa_api_tool_path', '', 'env')
     app.add_config_value('psa_api_template_path', '', 'env')
     app.add_config_value('psa_api_license', 'missing', 'env')
+    app.add_config_value('psa_api_api_version', '', 'env')
     app.add_config_value('psa_api_retval_order', [], 'env')
     app.add_config_value('psa_api_header_doxygen', 0, 'env')
     app.add_config_value('psa_api_front_sections', [], 'env')


### PR DESCRIPTION
GlobalPlatform document processes only updates a 4th 'draft revision' value in the document version during drafting and review of an updated specification, retaining the previous major.minor.patch version label.

When the draft is targeting a new API version, we want to configure the API version as a separate configuration value for the document.