### PR TITLE
Migrated document configuration to TOML

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Reference header files for each minor version of each API are provided in the [h
 
 This repository includes the documentation build tooling in [tools/]. The top-level `Makefile` uses that local tool copy by default, so a normal build does not require a separate checkout of the build tools.
 
-The HTML build requires Python, Sphinx, and `make`. PDF output also requires a LaTeX toolchain with `pdflatex`. Regenerating figures can require additional tools, depending on the figure source format, including Graphviz, `wavedrompy`, PlantUML, Java, and `rsvg-convert`.
+The HTML build requires Python 3.11 or later, Sphinx, and `make`. PDF output also requires a LaTeX toolchain with `pdflatex`. Regenerating figures can require additional tools, depending on the figure source format, including Graphviz, `wavedrompy`, PlantUML, Java, and `rsvg-convert`.
 
 Build one specification from the repository root with:
 

--- a/doc/attestation/conf.py
+++ b/doc/attestation/conf.py
@@ -1,71 +1,11 @@
-# SPDX-FileCopyrightText: Copyright 2018-2020, 2022-2026 Arm Limited and/or its affiliates
-# SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
-# SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
-
-# PSA API document configuration
-#
-# This is used to generate all of the sphinx configuration data and determine
-# the document file name etc.
-
-doc_info = {
-    # Document template
-    'template': 'psa-api-2026',
-
-    # Document title, MANDATORY
-    'title': 'PSA Attestation API',
-
-    # Document copyright date, default to year of 'date'
-    'copyright_date': '2018-2020, 2022-2026',
-
-    # Document identifier, marked as open issue if not provided
-    'doc_id': 'GPD_SPE_085',
-
-    # The short X.Y version. MANDATORY
-    'version': '2.0',
-    # Document maintenance revision
-    'issue_no': 0,
-    # Document draft revision
-    'draft': 1,
-    # Document status
-    'status': 'DFT',
-
-    # Id of the legal notice for this document
-    # Marked as open issue if not provided
-    #'license': 'psa-certified-api-license',
-
-    # Document date, default to build date
-    'date': 'May 2026',
-
-    # psa_spec: default header file for API definitions
-    # default to None, and can be set in documentation source
-    'header': 'psa/initial_attestation',
-
-    # Doxygen annotation level of the generated header
-    #    0 : None (default)
-    #    1 : Primary API elements
-    #    2 : Sub-elements of API - parameters, fields, values
-    'header_doxygen': 2,
-
-    # Declare a watermark for the PDF output
-    #'watermark': 'DRAFT',
-
-    # Include the C Identifier index. Default to True
-    'identifier_index': False,
-
-    # Specify where to add page breaks in main/appendix
-    #   'none'     : no page breaks
-    #   'appendix' : just before the appendices
-    #   'chapter'  : before every chapter
-    # Default to 'appendix'
-    'page_break': 'chapter'
-    }
-
-# Set up and run the psa-api-tool configuration
+# SPDX-FileCopyrightText: Copyright 2020-2026 Arm Limited and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 
 psa_api_tool_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', 'tools'))
 psa_api_tool_path = os.environ.get('PSA_API_TOOL') or psa_api_tool_path
+psa_api_config_path = os.path.join(os.path.dirname(__file__), 'psa-api.toml')
 exec(compile(open(os.path.join(psa_api_tool_path,'psa-api-conf.py'),
                   encoding='utf-8').read(),
              'psa-api-conf.py', 'exec'))

--- a/doc/attestation/psa-api.toml
+++ b/doc/attestation/psa-api.toml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright 2018-2020, 2022-2026 Arm Limited and/or its affiliates
+# SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
+# SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
+
+# Document identity
+template = "psa-api-2026"
+title = "PSA Attestation API"
+doc_id = "GPD_SPE_085"
+copyright_date = "2018-2020, 2022-2026"
+
+# Publication and lifecycle
+version = "2.0"
+issue_no = 0
+draft = 1
+status = "DFT"
+date = "May 2026"
+
+# API generation
+header = "psa/initial_attestation"
+header_doxygen = 2
+
+# Rendering and optional content
+identifier_index = false
+page_break = "chapter"

--- a/doc/crypto-driver/conf.py
+++ b/doc/crypto-driver/conf.py
@@ -1,85 +1,11 @@
-# SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates
-# SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
-# SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
-
-# PSA API document configuration
-#
-# This is used to generate all of the sphinx configuration data and determine
-# the document file name etc.
-
-doc_info = {
-    # Document template
-    'template': 'psa-api-2026',
-
-    # Document title, MANDATORY
-    'title': 'PSA Crypto Driver Interface',
-
-    # Document copyright date, default to year of 'date'
-    'copyright_date': '2020-2026',
-
-    # Document identifier, marked as open issue if not provided
-    'doc_id': '111106',
-
-    # The short X.Y version. MANDATORY
-    'version': '1.0',
-    # Document quality status, marked as open issue if not provided
-    'quality': 'ALP',
-   # Document maintenance revision
-    'issue_no': 1,
-    # Document draft revision
-    'draft': 1,
-    # Document status
-    'status': 'DFT',
-
-    # Id of the legal notice for this document
-    # Marked as open issue if not provided
-    #'license': 'psa-certified-api-license',
-
-    # Document date, default to build date
-    'date': 'September 2025',
-
-    # Default header file for API definitions
-    # default to None, and can be set in documentation source
-    #'header': 'psa/crypto',
-
-    # Doxygen annotation level of the generated header
-    #    0 : None (default)
-    #    1 : Primary API elements
-    #    2 : Sub-elements of API - parameters, fields, values
-    'header_doxygen': 2,
-
-   # List of optional content that should be included in the build.
-    # Valid options are:
-    #   'rationale' : This enables output of ..rationale:: directives
-    #   'banner'    : This enables output of the title page banner
-    #   'todo'      : This enables output of ..todo:: directives
-    'include_content': ['banner','rationale'],
-
-    # Optional ordering of return error values
-    # This list is used to create a standard ordering of return value responses
-    # throughout the document, irrespective of their ordering in the source text
-    # Return values that are not in the ordering are sorted above any that are in
-    # the list and appear in source text order.
-
-    #'error_order': [],
-
-    # Include the C Identifier index. Default to True
-    'identifier_index': False,
-
-    # Specify where to add page breaks in main/appendix
-    #   'none'     : no page breaks
-    #   'appendix' : just before the appendices
-    #   'chapter'  : before every chapter
-    # Default to 'appendix'
-    'page_break': 'chapter'
-    }
-
-# Set up and run the psa-api-tool configuration
+# SPDX-FileCopyrightText: Copyright 2020-2026 Arm Limited and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 
 psa_api_tool_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', 'tools'))
 psa_api_tool_path = os.environ.get('PSA_API_TOOL') or psa_api_tool_path
+psa_api_config_path = os.path.join(os.path.dirname(__file__), 'psa-api.toml')
 exec(compile(open(os.path.join(psa_api_tool_path,'psa-api-conf.py'),
                   encoding='utf-8').read(),
              'psa-api-conf.py', 'exec'))

--- a/doc/crypto-driver/psa-api.toml
+++ b/doc/crypto-driver/psa-api.toml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates
+# SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
+# SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
+
+# Document identity
+template = "psa-api-2026"
+title = "PSA Crypto Driver Interface"
+doc_id = "111106"
+copyright_date = "2020-2026"
+
+# Publication and lifecycle
+version = "1.0"
+quality = "ALP"
+issue_no = 1
+draft = 1
+status = "DFT"
+date = "September 2025"
+
+# API generation
+header_doxygen = 2
+
+# Rendering and optional content
+include_content = ["banner", "rationale"]
+identifier_index = false
+page_break = "chapter"

--- a/doc/crypto/conf.py
+++ b/doc/crypto/conf.py
@@ -1,98 +1,11 @@
-# SPDX-FileCopyrightText: Copyright 2018-2026 Arm Limited and/or its affiliates
-# SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
-# SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
-
-# PSA API document configuration
-#
-# This is used to generate all of the sphinx configuration data and determine
-# the document file name etc.
-
-doc_info = {
-    # Document template
-    'template': 'psa-api-2026',
-
-    # Document title, MANDATORY
-    'title': 'PSA Crypto API',
-
-    # Document copyright date, default to year of 'date'
-    'copyright_date': '2018-2026',
-
-    # Document identifier, marked as open issue if not provided
-    'doc_id': 'GPD_SPE_086',
-
-    # The short X.Y version. MANDATORY
-    'version': '1.5',
-    # Document maintenance revision
-    'issue_no': 0,
-    # Document draft revision
-    'draft': 1,
-    # Document status
-    'status': 'DFT',
-
-    # Id of the legal notice for this document
-    # Marked as open issue if not provided
-    #'license': 'psa-certified-api-license',
-
-    # Document date, default to build date
-    'date': 'June 2026',
-
-    # Default header file for API definitions
-    # default to None, and can be set in documentation source
-    #'header': 'psa/crypto',
-
-    # Doxygen annotation level of the generated header
-    #    0 : None (default)
-    #    1 : Primary API elements
-    #    2 : Sub-elements of API - parameters, fields, values
-    'header_doxygen': 2,
-
-    # Optional ordering of return error values
-    # This list is used to create a standard ordering of return value responses
-    # throughout the document, irrespective of their ordering in the source text
-    # Return values that are not in the ordering are sorted above any that are in
-    # the list and appear in source text order.
-
-    'error_order': [
-        'PSA_SUCCESS',
-        'PSA_ERROR_BAD_STATE',
-        'PSA_ERROR_INVALID_HANDLE',
-        'PSA_ERROR_NOT_PERMITTED',
-        'PSA_ERROR_INVALID_SIGNATURE',
-        'PSA_ERROR_ALREADY_EXISTS',
-        'PSA_ERROR_INSUFFICIENT_DATA',
-        'PSA_ERROR_BUFFER_TOO_SMALL',
-        'PSA_ERROR_INVALID_PADDING',
-        'PSA_ERROR_INVALID_ARGUMENT',
-        'PSA_ERROR_NOT_SUPPORTED',
-        'PSA_ERROR_INSUFFICIENT_ENTROPY',
-        'PSA_ERROR_INSUFFICIENT_MEMORY',
-        'PSA_ERROR_INSUFFICIENT_STORAGE',
-        'PSA_ERROR_COMMUNICATION_FAILURE',
-        'PSA_ERROR_CORRUPTION_DETECTED',
-        'PSA_ERROR_STORAGE_FAILURE',
-        'PSA_ERROR_DATA_CORRUPT',
-        'PSA_ERROR_DATA_INVALID'
-    ],
-
-    # Include the C Identifier index. Default to True
-    'identifier_index': True,
-
-    # Specify where to add page breaks in main/appendix
-    #   'none'     : no page breaks
-    #   'appendix' : just before the appendices
-    #   'chapter'  : before every chapter
-    # Default to 'appendix'
-    'page_break': 'chapter',
-
-    'prolog_files': ['/substitutions'],
-    }
-
-# Set up and run the psa-api-tool configuration
+# SPDX-FileCopyrightText: Copyright 2020-2026 Arm Limited and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 
 psa_api_tool_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', 'tools'))
 psa_api_tool_path = os.environ.get('PSA_API_TOOL') or psa_api_tool_path
+psa_api_config_path = os.path.join(os.path.dirname(__file__), 'psa-api.toml')
 exec(compile(open(os.path.join(psa_api_tool_path,'psa-api-conf.py'),
                   encoding='utf-8').read(),
              'psa-api-conf.py', 'exec'))

--- a/doc/crypto/psa-api.toml
+++ b/doc/crypto/psa-api.toml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright 2018-2026 Arm Limited and/or its affiliates
+# SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
+# SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
+
+# Document identity
+template = "psa-api-2026"
+title = "PSA Crypto API"
+doc_id = "GPD_SPE_086"
+copyright_date = "2018-2026"
+
+# Publication and lifecycle
+version = "1.5"
+issue_no = 0
+draft = 1
+status = "DFT"
+date = "June 2026"
+
+# API generation
+header_doxygen = 2
+error_order = [
+    "PSA_SUCCESS",
+    "PSA_ERROR_BAD_STATE",
+    "PSA_ERROR_INVALID_HANDLE",
+    "PSA_ERROR_NOT_PERMITTED",
+    "PSA_ERROR_INVALID_SIGNATURE",
+    "PSA_ERROR_ALREADY_EXISTS",
+    "PSA_ERROR_INSUFFICIENT_DATA",
+    "PSA_ERROR_BUFFER_TOO_SMALL",
+    "PSA_ERROR_INVALID_PADDING",
+    "PSA_ERROR_INVALID_ARGUMENT",
+    "PSA_ERROR_NOT_SUPPORTED",
+    "PSA_ERROR_INSUFFICIENT_ENTROPY",
+    "PSA_ERROR_INSUFFICIENT_MEMORY",
+    "PSA_ERROR_INSUFFICIENT_STORAGE",
+    "PSA_ERROR_COMMUNICATION_FAILURE",
+    "PSA_ERROR_CORRUPTION_DETECTED",
+    "PSA_ERROR_STORAGE_FAILURE",
+    "PSA_ERROR_DATA_CORRUPT",
+    "PSA_ERROR_DATA_INVALID",
+]
+
+# Rendering and optional content
+identifier_index = true
+page_break = "chapter"
+prolog_files = ["/substitutions"]

--- a/doc/fwu/conf.py
+++ b/doc/fwu/conf.py
@@ -1,75 +1,11 @@
-# SPDX-FileCopyrightText: Copyright 2020-2025 Arm Limited and/or its affiliates
-# SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
-# SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
-
-# PSA API specification configuration
-#
-# This is used to generate all of the sphinx configuration data and determine
-# the document file name etc.
-
-doc_info = {
-    # Document template
-    'template': 'psa-api-2026',
-
-    # Document title, MANDATORY
-    'title': 'PSA Firmware Update API',
-
-    # Document copyright date, default to year of 'date'
-    'copyright_date': '2020-2026',
-
-    # Document identifier, marked as open issue if not provided
-    'doc_id': 'GPD_SPE_093',
-
-    # The short X.Y version. MANDATORY
-    'version': '1.0',
-    # Document maintenance revision
-    'issue_no': 1,
-    # Document draft revision
-    'draft': 1,
-    # Document status
-    'status': 'DFT',
-
-    # Id of the legal notice for this document
-    # Marked as open issue if not provided
-    #'license': 'psa-certified-api-license',
-
-    # Document date, default to build date
-    'date': 'September 2025',
-
-    # psa_spec: default header file for API definitions
-    # default to None, and can be set in documentation source
-    'header': 'psa/update',
-
-    # Doxygen annotation level of the generated header
-    #    0 : None (default)
-    #    1 : Primary API elements
-    #    2 : Sub-elements of API - parameters, fields, values
-    'header_doxygen': 2,
-
-    # Declare a watermark for the PDF output
-    #'watermark': 'DRAFT',
-
-    'include_content': [
-        'rationale'
-    ],
-
-    # Include the C Identifier index. Default to True
-    'identifier_index': True,
-
-    # Specify where to add page breaks in main/appendix
-    #   'none'     : no page breaks
-    #   'appendix' : just before the appendices
-    #   'chapter'  : before every chapter
-    # Default to 'appendix'
-    'page_break': 'chapter',
-    }
-
-# Set up and run the psa-api-tool configuration
+# SPDX-FileCopyrightText: Copyright 2020-2026 Arm Limited and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 
 psa_api_tool_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', 'tools'))
 psa_api_tool_path = os.environ.get('PSA_API_TOOL') or psa_api_tool_path
+psa_api_config_path = os.path.join(os.path.dirname(__file__), 'psa-api.toml')
 exec(compile(open(os.path.join(psa_api_tool_path,'psa-api-conf.py'),
                   encoding='utf-8').read(),
              'psa-api-conf.py', 'exec'))

--- a/doc/fwu/psa-api.toml
+++ b/doc/fwu/psa-api.toml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright 2020-2025 Arm Limited and/or its affiliates
+# SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
+# SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
+
+# Document identity
+template = "psa-api-2026"
+title = "PSA Firmware Update API"
+doc_id = "GPD_SPE_093"
+copyright_date = "2020-2026"
+
+# Publication and lifecycle
+version = "1.0"
+issue_no = 1
+draft = 1
+status = "DFT"
+date = "September 2025"
+
+# API generation
+header = "psa/update"
+header_doxygen = 2
+
+# Rendering and optional content
+include_content = ["rationale"]
+identifier_index = true
+page_break = "chapter"

--- a/doc/status-code/conf.py
+++ b/doc/status-code/conf.py
@@ -1,76 +1,11 @@
-# SPDX-FileCopyrightText: Copyright 2022, 2024-2026 Arm Limited and/or its affiliates
-# SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
-# SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
-
-# PSA API document configuration
-#
-# This is used to generate all of the sphinx configuration data and determine
-# the document file name etc.
-
-doc_info = {
-    # Document template
-    'template': 'psa-api-2026',
-
-    # Document title, MANDATORY
-    'title': 'PSA Status code API',
-
-    # Document copyright date, default to year of 'date'
-    'copyright_date': '2017-2022, 2024-2026',
-
-    # Document identifier, marked as open issue if not provided
-    'doc_id': 'GPD_SPE_097',
-
-    # The short X.Y version. MANDATORY
-    'version': '1.0',
-    # Document maintenance revision
-    'issue_no': 5,
-    # Document draft revision
-    'draft': 1,
-    # Document status
-    'status': 'DFT',
-
-    # Id of the legal notice for this document
-    # Marked as open issue if not provided
-    #'license': 'psa-certified-api-license',
-
-    # Document date, default to build date
-    'date': 'January 2026',
-
-    # psa_spec: default header file for API definitions
-    # default to None, and can be set in documentation source
-    'header': 'psa/error',
-
-    # Doxygen annotation level of the generated header
-    #    0 : None (default)
-    #    1 : Primary API elements
-    #    2 : Sub-elements of API - parameters, fields, values
-    'header_doxygen': 2,
-
-    # Declare a watermark for the PDF output
-    #'watermark': 'DRAFT',
-
-    # List of optional content that should be included in the build.
-    # Valid options are:
-    #   'rationale' : This enables output of ..rationale:: directives
-    'include_content': [],
-
-    # Include the C Identifier index. Default to True
-    'identifier_index': True,
-
-    # Specify where to add page breaks in main/appendix
-    #   'none'     : no page breaks
-    #   'appendix' : just before the appendices
-    #   'chapter'  : before every chapter
-    # Default to 'appendix'
-    'page_break': 'chapter',
-    }
-
-# Set up and run the psa-api-tool configuration
+# SPDX-FileCopyrightText: Copyright 2020-2026 Arm Limited and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 
 psa_api_tool_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', 'tools'))
 psa_api_tool_path = os.environ.get('PSA_API_TOOL') or psa_api_tool_path
+psa_api_config_path = os.path.join(os.path.dirname(__file__), 'psa-api.toml')
 exec(compile(open(os.path.join(psa_api_tool_path,'psa-api-conf.py'),
                   encoding='utf-8').read(),
              'psa-api-conf.py', 'exec'))

--- a/doc/status-code/psa-api.toml
+++ b/doc/status-code/psa-api.toml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright 2022, 2024-2026 Arm Limited and/or its affiliates
+# SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
+# SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
+
+# Document identity
+template = "psa-api-2026"
+title = "PSA Status code API"
+doc_id = "GPD_SPE_097"
+copyright_date = "2017-2022, 2024-2026"
+
+# Publication and lifecycle
+version = "1.0"
+issue_no = 5
+draft = 1
+status = "DFT"
+date = "January 2026"
+
+# API generation
+header = "psa/error"
+header_doxygen = 2
+
+# Rendering and optional content
+include_content = []
+identifier_index = true
+page_break = "chapter"

--- a/doc/storage/conf.py
+++ b/doc/storage/conf.py
@@ -1,86 +1,11 @@
-# SPDX-FileCopyrightText: Copyright 2018-2019, 2022-2026 Arm Limited and/or its affiliates
-# SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
-# SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
-
-# PSA API document configuration
-#
-# This is used to generate all of the sphinx configuration data and determine
-# the document file name etc.
-
-doc_info = {
-    # Document template
-    'template': 'psa-api-2026',
-
-    # Document title, MANDATORY
-    'title': 'PSA Secure Storage API',
-
-    # Document copyright date, default to year of 'date'
-    'copyright_date': '2018-2019, 2022-2026',
-
-    # Document identifier, marked as open issue if not provided
-    'doc_id': 'GPD_SPE_087',
-
-    # The short X.Y version. MANDATORY
-    'version': '1.0',
-    # Document maintenance revision
-    'issue_no': 4,
-    # Document draft revision
-    'draft': 1,
-    # Document status
-    'status': 'DFT',
-
-    # Id of the legal notice for this document
-    # Marked as open issue if not provided
-    #'license': 'psa-certified-api-license',
-
-    # Document date, default to build date
-    'date': 'September 2025',
-
-    # psa_spec: default header file for API definitions
-    # default to None, and can be set in documentation source
-    #'header': '',
-
-    # Doxygen annotation level of the generated header
-    #    0 : None (default)
-    #    1 : Primary API elements
-    #    2 : Sub-elements of API - parameters, fields, values
-    'header_doxygen': 2,
-
-    # Optional ordering of return error values
-    # This list is used to create a standard ordering of return value responses
-    # throughout the document, irrespective of their ordering in the source text
-    # Return values that are not in the ordering are sorted above any that are in
-    # the list and appear in source text order.
-
-    'error_order': [
-        'PSA_SUCCESS',
-        'PSA_ERROR_NOT_PERMITTED',
-        'PSA_ERROR_INVALID_SIGNATURE',
-        'PSA_ERROR_DOES_NOT_EXIST',
-        'PSA_ERROR_INVALID_ARGUMENT',
-        'PSA_ERROR_NOT_SUPPORTED',
-        'PSA_ERROR_INSUFFICIENT_STORAGE',
-        'PSA_ERROR_STORAGE_FAILURE',
-        'PSA_ERROR_DATA_CORRUPT',
-    ],
-
-    # Include the C Identifier index. Default to True
-    'identifier_index': True,
-
-    # Specify where to add page breaks in main/appendix
-    #   'none'     : no page breaks
-    #   'appendix' : just before the appendices
-    #   'chapter'  : before every chapter
-    # Default to 'appendix'
-    'page_break': 'chapter',
-    }
-
-# Set up and run the psa-api-tool configuration
+# SPDX-FileCopyrightText: Copyright 2020-2026 Arm Limited and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 
 psa_api_tool_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', 'tools'))
 psa_api_tool_path = os.environ.get('PSA_API_TOOL') or psa_api_tool_path
+psa_api_config_path = os.path.join(os.path.dirname(__file__), 'psa-api.toml')
 exec(compile(open(os.path.join(psa_api_tool_path,'psa-api-conf.py'),
                   encoding='utf-8').read(),
              'psa-api-conf.py', 'exec'))

--- a/doc/storage/psa-api.toml
+++ b/doc/storage/psa-api.toml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright 2018-2019, 2022-2026 Arm Limited and/or its affiliates
+# SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
+# SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
+
+# Document identity
+template = "psa-api-2026"
+title = "PSA Secure Storage API"
+doc_id = "GPD_SPE_087"
+copyright_date = "2018-2019, 2022-2026"
+
+# Publication and lifecycle
+version = "1.0"
+issue_no = 4
+draft = 1
+status = "DFT"
+date = "September 2025"
+
+# API generation
+header_doxygen = 2
+error_order = [
+    "PSA_SUCCESS",
+    "PSA_ERROR_NOT_PERMITTED",
+    "PSA_ERROR_INVALID_SIGNATURE",
+    "PSA_ERROR_DOES_NOT_EXIST",
+    "PSA_ERROR_INVALID_ARGUMENT",
+    "PSA_ERROR_NOT_SUPPORTED",
+    "PSA_ERROR_INSUFFICIENT_STORAGE",
+    "PSA_ERROR_STORAGE_FAILURE",
+    "PSA_ERROR_DATA_CORRUPT",
+]
+
+# Rendering and optional content
+identifier_index = true
+page_break = "chapter"

--- a/tools/docs/using-psa-api-tool.md
+++ b/tools/docs/using-psa-api-tool.md
@@ -37,10 +37,10 @@ By default, builds use the checked-in tool under `tools/`. Editors can override
 make PSA_API_TOOL=/path/to/psa-api-tool doc/crypto/html
 ```
 
-Each specification has its own `conf.py` under `doc/<spec>/`. The document configuration
-sets `psa_api_tool_path` to the repository `tools/` directory, allows the `PSA_API_TOOL`
-environment variable to override that path, then executes `psa-api-conf.py` from the
-selected tool copy.
+Each specification has its own `conf.py` and `psa-api.toml` under `doc/<spec>/`.
+The small `conf.py` shim sets `psa_api_tool_path` to the repository `tools/` directory,
+allows the `PSA_API_TOOL` environment variable to override that path, provides the TOML
+file path, then executes `psa-api-conf.py` from the selected tool copy.
 
 Each specification directory also contains a minimal `pyproject.toml` file. These files
 act as project-boundary markers for editor integrations such as Esbonio, allowing each
@@ -60,7 +60,7 @@ make -f /path/to/psa-api-tool/make doc/crypto/html
 
 The core HTML and structured-output build path requires:
 
-- Python 3.
+- Python 3.11 or later.
 - Sphinx.
 - A POSIX-like shell and `make`.
 
@@ -84,8 +84,9 @@ optional.
 ### Version and Platform Guidance
 
 The build tooling is not currently defined by a pinned requirements file or a repeatable
-CI environment. Contributors should report the tool and platform versions used when
-diagnosing build differences.
+CI environment. Python 3.11 is the minimum supported version; this provides the standard
+library TOML support used by TOML-backed document configurations. Contributors should
+report the tool and platform versions used when diagnosing build differences.
 
 The integrated tool introduction branch has been tested on macOS arm64 with Python
 3.13.7, Sphinx 8.1.0, GNU Make 3.81, MiKTeX-pdfTeX 4.10, OpenJDK 21.0.2, PlantUML
@@ -209,37 +210,57 @@ not rendering as expected.
 
 ## Document Configuration
 
-Each document `conf.py` defines a `doc_info` dictionary and then executes the shared
-tool configuration. Keep document configuration focused on document metadata and
-document-specific choices. Avoid setting Sphinx configuration variables directly in
-`conf.py` unless the shared configuration cannot support the required behavior.
+Each document's `psa-api.toml` defines its metadata. Keep document configuration focused
+on document metadata and document-specific choices. The keys map directly to the common
+tool configuration; the `conf.py` shim should not contain document metadata or set Sphinx
+configuration variables directly.
 
-The current PSA API documents use the Arm-style `psa-api-2022` and `psa-api-2025`
-templates. These templates preserve the existing front matter and release metadata model
-while allowing the repository to build without an external `atg-sphinx-spec` checkout.
+The current PSA API documents use the `psa-api-2026` template. It preserves the current
+front matter and release metadata model while allowing the repository to build without an
+external `atg-sphinx-spec` checkout.
 
-Important `doc_info` keys used by these specifications include:
+For example:
+
+```toml
+# Document identity
+template = "psa-api-2026"
+title = "Example API"
+doc_id = "GPD_SPE_000"
+
+# Publication and lifecycle
+version = "1.0"
+issue_no = 0
+draft = 1
+status = "DFT"
+
+# API generation
+header_doxygen = 2
+```
+
+Important TOML keys used by these specifications include:
 
 | Key | Purpose |
 | --- | --- |
 | `template` | Template directory under `tools/templates/`. |
 | `title` | Document title used by Sphinx and the title page. |
-| `version` | Required document lifecycle version. This is the Sphinx version and is used for document release labels, filenames, and `|docversion|`. |
-| `api_version` | Optional target API version, normally `X.Y`. It defaults to `version` for compatibility. It is used for `|APIversion|`, `|majorversion|`, `|minorversion|`, `|hexversion|`, and `:api-version:` macro values. |
+| `version` | Required document major.minor version. This is the Sphinx version and is used for document release labels, filenames, and `|docversion|`. |
+| `api_version` | Optional target API major.minor version. It defaults to `version` for compatibility. It is used for `|APIversion|`, `|majorversion|`, `|minorversion|`, `|hexversion|`, and `:api-version:` macro values. |
 | `issue_no` | Document issue or maintenance revision. |
 | `draft` | Draft flag or draft revision, depending on the selected publication model. |
+| `status` | Document lifecycle status, such as `DFT` or `PUB`. |
 | `release_candidate` | Release-candidate number for existing Arm-style documents. |
 | `quality` | API maturity code such as `ALP`, `BET`, or `REL`. |
 | `header` | Default generated C header path for API directives. |
 | `header_doxygen` | Generated header annotation level. |
 | `error_order` | Document-wide order for generated return values. |
+| `include_content` | Optional content to render, such as `banner` or `rationale`. |
 | `identifier_index` | Controls the generated C identifier index. |
+| `page_break` | PDF page-break policy: `none`, `appendix`, or `chapter`. |
 | `prolog_files` | Shared substitution files included in the Sphinx prolog. |
 
-`version` identifies the document lifecycle version. The optional `api_version`
-identifies the API described by the document and must use `X.Y` format. If it is
-omitted, the tool derives the API version from the document version's major and
-minor components, so a document version of `1.5.0` describes API version `1.5`.
+`version` identifies the document lifecycle version, in `X.Y` format. The optional
+`api_version` identifies the API described by the document and also uses `X.Y`
+format. If it is omitted, the tool derives the API version from the document version.
 
 An explicit `api_version` can match the document's major/minor version. For a
 non-published document it can instead target only the next minor version or the
@@ -249,6 +270,10 @@ with a configuration diagnostic.
 
 For detailed directive and role behavior, use `psa-api-tool-notes.md` as the editing
 reference.
+
+Legacy document trees can continue to define the same keys in a Python `doc_info`
+dictionary. The shared tool uses that dictionary when it is present; it otherwise loads
+the `psa_api_config_path` supplied by the local shim.
 
 ----
 

--- a/tools/psa-api-conf.py
+++ b/tools/psa-api-conf.py
@@ -11,9 +11,10 @@
 # This script is included and executed as part of conf.py, it is not a
 # standalone python module or script.
 #
-# conf.py must have set up:
+# conf.py must have set up either:
 # * a dictionary doc_info, with project specific information and
-#   configuration.
+#   configuration; or
+# * a path psa_api_config_path to a TOML file containing the doc_info values.
 # * a string path psa_api_tool_path that defines the the path containing this
 #   file, either relative to conf.py, or absolute.
 #
@@ -21,6 +22,32 @@
 import sys, os, re
 from datetime import date
 import importlib
+
+def load_doc_info(path):
+    try:
+        import tomllib
+    except ModuleNotFoundError as error:
+        raise RuntimeError(
+            'TOML document configuration requires Python 3.11 or later.') from error
+    try:
+        with open(path, 'rb') as config_file:
+            return tomllib.load(config_file)
+    except FileNotFoundError as error:
+        raise RuntimeError(
+            'Document configuration TOML file "{}" was not found.'.format(path)) from error
+    except OSError as error:
+        raise RuntimeError(
+            'Cannot read document configuration TOML file "{}": {}.'.format(path, error)) from error
+    except tomllib.TOMLDecodeError as error:
+        raise RuntimeError(
+            'Invalid TOML in document configuration file "{}": {}.'.format(path, error)) from error
+
+if 'doc_info' not in globals():
+    try:
+        doc_info = load_doc_info(psa_api_config_path)
+    except NameError as error:
+        raise RuntimeError(
+            'conf.py must define doc_info or psa_api_config_path.') from error
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
Each specification's metadata is now maintained in a psa-api.toml file in the document source folder. conf.py is reduced to a common script that identifies the required copy of the tools, sets the path to the configuration data, and invokes the shared tooling.

Maintaining the config data as TOML is easier and less error-prone that editing the previous python scripts.