### PR TITLE
Clarify Crypto buffer access lifetime

### DIFF
--- a/doc/crypto/appendix/history.rst
+++ b/doc/crypto/appendix/history.rst
@@ -18,6 +18,7 @@ Changes in the draft GlobalPlatform publication revision
 Clarifications and fixes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+*   Clarified that an implementation accesses memory referenced by a pointer or buffer parameter only during the function call, and consumes input buffers before returning.
 *   Corrected the WPA3-SAE operation example code: the send-confirm counter input step is `PSA_PAKE_STEP_CONFIRM_COUNT`, and the shared key is extracted from the ``wpa3_sae`` operation.
 *   Corrected the SPAKE2+ operation example code: the Prover input step for the Verifier confirmation value is `PSA_PAKE_STEP_CONFIRM`.
 

--- a/doc/crypto/overview/conventions.rst
+++ b/doc/crypto/overview/conventions.rst
@@ -211,6 +211,11 @@ readable, and the implementation must be able to write to a non-buffer output
 parameter and read back the same value, as explained in
 :secref:`stability-of-parameters`.
 
+The implementation accesses memory referenced by a pointer or buffer parameter
+only during the function call. In particular, it must consume input buffers
+before returning and must not access the caller's memory after the function
+returns.
+
 Input buffer sizes
 ^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This is buffer behaviour convention that has always been assumed/expected in the PSA APIs, but is not explicitly stated in the Crypto API specification.