### PR TITLE
Clarified the `PSA_ERROR_BAD_STATE` conditions for multi-part operations

### DIFF
--- a/doc/crypto/api/ops/aead.rst
+++ b/doc/crypto/api/ops/aead.rst
@@ -1,4 +1,5 @@
 .. SPDX-FileCopyrightText: Copyright 2018-2025 Arm Limited and/or its affiliates
+.. SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -474,7 +475,7 @@ Multi-part AEAD operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_HANDLE
         ``key`` is not a valid key identifier.
@@ -538,7 +539,7 @@ Multi-part AEAD operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_HANDLE
         ``key`` is not a valid key identifier.
@@ -601,7 +602,8 @@ Multi-part AEAD operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, and `psa_aead_set_nonce()` and `psa_aead_generate_nonce()` must not have been called yet.
+        *   The operation is not active.
+        *   A call to `psa_aead_set_nonce()` or `psa_aead_generate_nonce()` has already been made.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         ``ad_length`` or ``plaintext_length`` are too large for the chosen algorithm.
@@ -643,8 +645,10 @@ Multi-part AEAD operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be an active AEAD encryption operation, with no nonce set.
-        *   The operation state is not valid: this is an algorithm which requires `psa_aead_set_lengths()` to be called before setting the nonce.
+        *   The operation is not active.
+        *   The operation was not set up with `psa_aead_encrypt_setup()`.
+        *   A nonce has already been set.
+        *   The algorithm requires a call to `psa_aead_set_lengths()` before the nonce is set, and no such call has been made.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``nonce`` buffer is too small. `PSA_AEAD_NONCE_LENGTH()` or `PSA_AEAD_NONCE_MAX_SIZE` can be used to determine a sufficient buffer size.
@@ -682,8 +686,9 @@ Multi-part AEAD operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, with no nonce set.
-        *   The operation state is not valid: this is an algorithm which requires `psa_aead_set_lengths()` to be called before setting the nonce.
+        *   The operation is not active.
+        *   A nonce has already been set.
+        *   The algorithm requires a call to `psa_aead_set_lengths()` before the nonce is set, and no such call has been made.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         ``nonce_length`` is not valid for the chosen algorithm.
@@ -729,7 +734,10 @@ Multi-part AEAD operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, have a nonce set, have lengths set if required by the algorithm, and `psa_aead_update()` must not have been called yet.
+        *   The operation is not active.
+        *   No nonce has been set.
+        *   The algorithm requires a call to `psa_aead_set_lengths()`, and no such call has been made.
+        *   A call to `psa_aead_update()` has already been made.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         Excess additional data: the total input length to `psa_aead_update_ad()` is greater than the additional data length that was previously specified with `psa_aead_set_lengths()`, or is too large for the chosen AEAD algorithm.
@@ -788,7 +796,9 @@ Multi-part AEAD operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, have a nonce set, and have lengths set if required by the algorithm.
+        *   The operation is not active.
+        *   No nonce has been set.
+        *   The algorithm requires a call to `psa_aead_set_lengths()`, and no such call has been made.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``output`` buffer is too small. `PSA_AEAD_UPDATE_OUTPUT_SIZE()` or `PSA_AEAD_UPDATE_OUTPUT_MAX_SIZE()` can be used to determine a sufficient buffer size.
@@ -854,7 +864,9 @@ Multi-part AEAD operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be an active encryption operation with a nonce set.
+        *   The operation is not active.
+        *   The operation was not set up with `psa_aead_encrypt_setup()`.
+        *   No nonce has been set.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``ciphertext`` or ``tag`` buffer is too small.
@@ -914,7 +926,9 @@ Multi-part AEAD operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be an active decryption operation with a nonce set.
+        *   The operation is not active.
+        *   The operation was not set up with `psa_aead_decrypt_setup()`.
+        *   No nonce has been set.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``plaintext`` buffer is too small. `PSA_AEAD_VERIFY_OUTPUT_SIZE()` or `PSA_AEAD_VERIFY_OUTPUT_MAX_SIZE` can be used to determine a sufficient buffer size.

--- a/doc/crypto/api/ops/cipher.rst
+++ b/doc/crypto/api/ops/cipher.rst
@@ -1,4 +1,5 @@
 .. SPDX-FileCopyrightText: Copyright 2018-2025 Arm Limited and/or its affiliates
+.. SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -560,7 +561,7 @@ Multi-part cipher operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
 
     The sequence of operations to encrypt a message with a symmetric cipher is as follows:
@@ -622,7 +623,7 @@ Multi-part cipher operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
 
     The sequence of operations to decrypt a message with a symmetric cipher is as follows:
@@ -667,7 +668,9 @@ Multi-part cipher operations
         The following conditions can result in this error:
 
         *   The cipher algorithm does not use an IV.
-        *   The operation state is not valid: it must be active, with no IV set.
+        *   The operation is not active.
+        *   The operation was not set up with `psa_cipher_encrypt_setup()`.
+        *   An IV has already been set.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``iv`` buffer is too small. `PSA_CIPHER_IV_LENGTH()` or `PSA_CIPHER_IV_MAX_SIZE` can be used to determine a sufficient buffer size.
@@ -708,7 +711,8 @@ Multi-part cipher operations
         The following conditions can result in this error:
 
         *   The cipher algorithm does not use an IV.
-        *   The operation state is not valid: it must be an active cipher encrypt operation, with no IV set.
+        *   The operation is not active.
+        *   An IV has already been set.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The following conditions can result in this error:
@@ -764,7 +768,8 @@ Multi-part cipher operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, with an IV set if required for the algorithm.
+        *   The operation is not active.
+        *   The cipher algorithm requires an IV, and no IV has been set.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``output`` buffer is too small. `PSA_CIPHER_UPDATE_OUTPUT_SIZE()` or `PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE()` can be used to determine a sufficient buffer size.
@@ -819,7 +824,8 @@ Multi-part cipher operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, with an IV set if required for the algorithm.
+        *   The operation is not active.
+        *   The cipher algorithm requires an IV, and no IV has been set.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``output`` buffer is too small. `PSA_CIPHER_FINISH_OUTPUT_SIZE()` or `PSA_CIPHER_FINISH_OUTPUT_MAX_SIZE` can be used to determine a sufficient buffer size.

--- a/doc/crypto/api/ops/hash.rst
+++ b/doc/crypto/api/ops/hash.rst
@@ -1,4 +1,5 @@
 .. SPDX-FileCopyrightText: Copyright 2018-2026 Arm Limited and/or its affiliates
+.. SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -557,7 +558,7 @@ Multi-part hashing operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
@@ -600,7 +601,7 @@ Multi-part hashing operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active.
+        *   The operation is not active.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The total input for the operation is too large for the hash algorithm.
@@ -635,7 +636,7 @@ Multi-part hashing operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active.
+        *   The operation is not active.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``hash`` buffer is too small.
@@ -674,7 +675,7 @@ Multi-part hashing operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active.
+        *   The operation is not active.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
@@ -736,7 +737,7 @@ Multi-part hashing operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active.
+        *   The operation is not active.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``hash_state`` buffer is too small.
@@ -802,7 +803,7 @@ Multi-part hashing operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
@@ -832,8 +833,8 @@ Multi-part hashing operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The ``source_operation`` state is not valid: it must be active.
-        *   The ``target_operation`` state is not valid: it must be inactive.
+        *   ``source_operation`` is not active.
+        *   ``target_operation`` is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED

--- a/doc/crypto/api/ops/key-derivation.rst
+++ b/doc/crypto/api/ops/key-derivation.rst
@@ -1,4 +1,5 @@
 .. SPDX-FileCopyrightText: Copyright 2018-2026 Arm Limited and/or its affiliates
+.. SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -653,7 +654,7 @@ Key-derivation functions
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
 
     A key-derivation algorithm takes some inputs and uses them to generate a byte stream in a deterministic way. This byte stream can be used to produce keys and other cryptographic material.
@@ -696,7 +697,7 @@ Key-derivation functions
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active.
+        *   The operation is not active.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
 
@@ -723,7 +724,7 @@ Key-derivation functions
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active.
+        *   The operation is not active.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
@@ -771,7 +772,9 @@ Key-derivation functions
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid for this input ``step``. This can happen if the application provides a step out of order or repeats a step that may not be repeated.
+        *   The operation is not active.
+        *   The operation has already produced output.
+        *   The input ``step`` is out of order or has already been provided, and the algorithm does not permit repeating it.
         *   The library requires initializing by a call to `psa_crypto_init()`.
 
     Which inputs are required and in what order depends on the algorithm. Refer to the documentation of each key-derivation or key-agreement algorithm for information.
@@ -817,7 +820,9 @@ Key-derivation functions
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid for this input ``step``. This can happen if the application provides a step out of order or repeats a step that may not be repeated.
+        *   The operation is not active.
+        *   The operation has already produced output.
+        *   The input ``step`` is out of order or has already been provided, and the algorithm does not permit repeating it.
         *   The library requires initializing by a call to `psa_crypto_init()`.
 
     Which inputs are required and in what order depends on the algorithm.
@@ -869,7 +874,9 @@ Key-derivation functions
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid for this input ``step``. This can happen if the application provides a step out of order or repeats a step that may not be repeated.
+        *   The operation is not active.
+        *   The operation has already produced output.
+        *   The input ``step`` is out of order or has already been provided, and the algorithm does not permit repeating it.
         *   The library requires initializing by a call to `psa_crypto_init()`.
 
     Which inputs are required and in what order depends on the algorithm. Refer to the documentation of each key-derivation or key-agreement algorithm for information.
@@ -914,7 +921,8 @@ Key-derivation functions
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, with all required input steps complete.
+        *   The operation is not active.
+        *   Not all required input steps have been completed.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
@@ -1000,7 +1008,8 @@ Key-derivation functions
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, with all required input steps complete.
+        *   The operation is not active.
+        *   Not all required input steps have been completed.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_INSUFFICIENT_STORAGE
@@ -1113,7 +1122,8 @@ Key-derivation functions
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, with all required input steps complete.
+        *   The operation is not active.
+        *   Not all required input steps have been completed.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_INSUFFICIENT_STORAGE
@@ -1162,7 +1172,8 @@ Key-derivation functions
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, with all required input steps complete.
+        *   The operation is not active.
+        *   Not all required input steps have been completed.
         *   The library requires initializing by a call to `psa_crypto_init()`.
 
     This function calculates output bytes from a key-derivation algorithm and compares those bytes to an expected value.
@@ -1230,7 +1241,8 @@ Key-derivation functions
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, with all required input steps complete.
+        *   The operation is not active.
+        *   Not all required input steps have been completed.
         *   The library requires initializing by a call to `psa_crypto_init()`.
 
     This function calculates output bytes from a key-derivation algorithm and compares those bytes to an expected value, provided as key of type `PSA_KEY_TYPE_PASSWORD_HASH`.

--- a/doc/crypto/api/ops/mac.rst
+++ b/doc/crypto/api/ops/mac.rst
@@ -1,4 +1,5 @@
 .. SPDX-FileCopyrightText: Copyright 2018-2026 Arm Limited and/or its affiliates
+.. SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -468,7 +469,7 @@ Multi-part MAC operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
 
     This function sets up the calculation of the message authentication code (MAC) of a byte string. To verify the MAC of a message against an expected value, use `psa_mac_verify_setup()` instead.
@@ -531,7 +532,7 @@ Multi-part MAC operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
 
     This function sets up the verification of the message authentication code (MAC) of a byte string against an expected value.
@@ -573,7 +574,7 @@ Multi-part MAC operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active.
+        *   The operation is not active.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The total input for the operation is too large for the MAC algorithm.
@@ -617,7 +618,8 @@ Multi-part MAC operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be an active mac sign operation.
+        *   The operation is not active.
+        *   The operation was set up with `psa_mac_verify_setup()`.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``mac`` buffer is too small.
@@ -659,7 +661,8 @@ Multi-part MAC operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be an active mac verify operation.
+        *   The operation is not active.
+        *   The operation was set up with `psa_mac_sign_setup()`.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE

--- a/doc/crypto/api/ops/pake.rst
+++ b/doc/crypto/api/ops/pake.rst
@@ -1,4 +1,5 @@
 .. SPDX-FileCopyrightText: Copyright 2022-2025 Arm Limited and/or its affiliates
+.. SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -784,7 +785,7 @@ Multi-part PAKE operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_HANDLE
         ``password_key`` is not a valid key identifier.
@@ -861,7 +862,8 @@ Multi-part PAKE operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, and `psa_pake_set_role()`, `psa_pake_input()`, and `psa_pake_output()` must not have been called yet.
+        *   The operation is not active.
+        *   A call to `psa_pake_set_role()`, `psa_pake_input()`, or `psa_pake_output()` has already been made.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The following conditions can result in this error:
@@ -904,7 +906,8 @@ Multi-part PAKE operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, and `psa_pake_set_user()`, `psa_pake_input()`, and `psa_pake_output()` must not have been called yet.
+        *   The operation is not active.
+        *   A call to `psa_pake_set_user()`, `psa_pake_input()`, or `psa_pake_output()` has already been made.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         ``user_id`` is not valid for the operation's algorithm and cipher suite.
@@ -940,7 +943,8 @@ Multi-part PAKE operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, and `psa_pake_set_peer()`, `psa_pake_input()`, and `psa_pake_output()` must not have been called yet.
+        *   The operation is not active.
+        *   A call to `psa_pake_set_peer()`, `psa_pake_input()`, or `psa_pake_output()` has already been made.
         *   Calling `psa_pake_set_peer()` is invalid with the operation's algorithm.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
@@ -977,7 +981,8 @@ Multi-part PAKE operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, and `psa_pake_set_context()`, `psa_pake_input()`, and `psa_pake_output()` must not have been called yet.
+        *   The operation is not active.
+        *   A call to `psa_pake_set_context()`, `psa_pake_input()`, or `psa_pake_output()` has already been made.
         *   Calling `psa_pake_set_context()` is invalid with the operation's algorithm.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
@@ -1023,7 +1028,9 @@ Multi-part PAKE operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active and fully set up, and this call must conform to the algorithm's requirements for ordering of input and output steps.
+        *   The operation is not active.
+        *   The operation is not fully set up.
+        *   The call does not conform to the algorithm's requirements for ordering input and output steps.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         ``step`` is not compatible with the operation's algorithm.
@@ -1070,7 +1077,9 @@ Multi-part PAKE operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active and fully set up, and this call must conform to the algorithm's requirements for ordering of input and output steps.
+        *   The operation is not active.
+        *   The operation is not fully set up.
+        *   The call does not conform to the algorithm's requirements for ordering input and output steps.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The following conditions can result in this error:
@@ -1147,11 +1156,10 @@ Multi-part PAKE operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The state of PAKE operation ``operation`` is not valid: it must be ready to return the shared secret.
-
-            For an unconfirmed key, this will be when the key-exchange output and input steps are complete, but prior to any key-confirmation output and input steps.
-
-            For a confirmed key, this will be when all key-exchange and key-confirmation output and input steps are complete.
+        *   The operation is not active.
+        *   The key-exchange input and output steps are not complete.
+        *   The operation is configured for an unconfirmed key, and a key-confirmation input or output step has been performed.
+        *   The operation is configured for a confirmed key, and the key-confirmation input and output steps are not complete.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_ALREADY_EXISTS
         This is an attempt to create a persistent key, and there is already a persistent key with the given identifier.

--- a/doc/crypto/api/ops/signature.rst
+++ b/doc/crypto/api/ops/signature.rst
@@ -1,4 +1,5 @@
 .. SPDX-FileCopyrightText: Copyright 2018-2026 Arm Limited and/or its affiliates
+.. SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -2302,7 +2303,7 @@ Multi-part asymmetric signature operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
 
     The sequence of operations to sign a message using a multi-part sign operation is as follows:
@@ -2348,7 +2349,8 @@ Multi-part asymmetric signature operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, and no call to `psa_sign_set_context()` or `psa_sign_update()` has been made.
+        *   The operation is not active.
+        *   A call to `psa_sign_set_context()` or `psa_sign_update()` has already been made.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The following conditions can result in this error:
@@ -2396,7 +2398,7 @@ Multi-part asymmetric signature operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active.
+        *   The operation is not active.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The total input for the operation is too large for the signature algorithm.
@@ -2439,7 +2441,7 @@ Multi-part asymmetric signature operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active.
+        *   The operation is not active.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``signature`` buffer is too small.
@@ -2584,7 +2586,7 @@ Multi-part asymmetric signature operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
 
     The sequence of operations to verify a message signature using a multi-part verify operation is as follows:
@@ -2630,7 +2632,8 @@ Multi-part asymmetric signature operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, and no call to `psa_verify_set_context()` or `psa_verify_update()` has been made.
+        *   The operation is not active.
+        *   A call to `psa_verify_set_context()` or `psa_verify_update()` has already been made.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The following conditions can result in this error:
@@ -2678,7 +2681,7 @@ Multi-part asymmetric signature operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active.
+        *   The operation is not active.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The total input for the operation is too large for the signature algorithm.
@@ -2713,7 +2716,7 @@ Multi-part asymmetric signature operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active.
+        *   The operation is not active.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE

--- a/doc/crypto/api/ops/xof.rst
+++ b/doc/crypto/api/ops/xof.rst
@@ -1,4 +1,5 @@
 .. SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates
+.. SPDX-FileCopyrightText: Copyright 2026 GlobalPlatform
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -180,7 +181,7 @@ Multi-part XOF operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be inactive.
+        *   The operation is not inactive.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
@@ -224,7 +225,8 @@ Multi-part XOF operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, and no call to `psa_xof_set_context()`, `psa_xof_update()`, or `psa_xof_output()` has been made.
+        *   The operation is not active.
+        *   A call to `psa_xof_set_context()`, `psa_xof_update()`, or `psa_xof_output()` has already been made.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The following conditions can result in this error:
@@ -268,7 +270,8 @@ Multi-part XOF operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active, and no call to `psa_xof_output()` has been made.
+        *   The operation is not active.
+        *   A call to `psa_xof_output()` has already been made.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The total input for the operation is too large for the XOF algorithm.
@@ -308,7 +311,7 @@ Multi-part XOF operations
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
 
-        *   The operation state is not valid: it must be active.
+        *   The operation is not active.
         *   The library requires initializing by a call to `psa_crypto_init()`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE

--- a/doc/crypto/appendix/history.rst
+++ b/doc/crypto/appendix/history.rst
@@ -20,6 +20,7 @@ Clarifications and fixes
 
 *   Corrected the WPA3-SAE operation example code: the send-confirm counter input step is `PSA_PAKE_STEP_CONFIRM_COUNT`, and the shared key is extracted from the ``wpa3_sae`` operation.
 *   Corrected the SPAKE2+ operation example code: the Prover input step for the Verifier confirmation value is `PSA_PAKE_STEP_CONFIRM`.
+*   Clarified the `PSA_ERROR_BAD_STATE` conditions for multi-part hash, XOF, MAC, cipher, AEAD, asymmetric signature, key-derivation, and PAKE operations.
 
 Other changes
 ~~~~~~~~~~~~~


### PR DESCRIPTION
In the discussion of #375, which introduces additional operation objects with complex implied state-models, it was noted that the phrasing of the valid/invalid operation states which can give rise to a `PSA_ERROR_BAD_STATE` error had become complicated, and in places, confusing.

A change in the pattern of these condition clauses is introduced in #375 for the interruptible operations. This PR applies the same pattern to the existing multi-part hash, XOF, MAC, cipher, AEAD, asymmetric signature, key-derivation, and PAKE operations.

Where previously these clauses had been phrased:

> The operation state is not valid: <description of the valid states for this function>

these are now changed to a set of clauses, any of which are sufficient to result in a `PSA_ERROR_BAD_STATE` response. The result is a pattern that closely matches the style used for other error return values where more than one condition can result in the error.